### PR TITLE
New examples from various times

### DIFF
--- a/CopyrightEntries.dtd
+++ b/CopyrightEntries.dtd
@@ -1,45 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!ELEMENT copyrightEntries (copyrightEntry+) >
-<!ELEMENT copyrightEntry (title?, author*, desc?, edition?, pubPlace?, publisher?, volumes?, series?, issuedInAnotherWork?, otherauthor*, employerName*, prev-regnum?,
-                          newMatterClaimed?, pubDate?, pubName?, claimant?, claimantPlace?, regDate?, classCode?, copies?, affDate?,
-			  vol?, noticeDate?, see?)>
+<!ELEMENT copyrightEntry ANY>
 <!ATTLIST copyrightEntry
 	  id NMTOKEN #REQUIRED
 	  regnum NMTOKEN #IMPLIED>
 <!ELEMENT title (#PCDATA)>
-<!ELEMENT author (authorName, authorBirth?, authorDeath?)>
+<!ELEMENT author (#PCDATA | role | authorName|  authorBirth | authorDeath)*>
 <!ATTLIST author
 	  role NMTOKEN #IMPLIED>
 <!ELEMENT authorName (#PCDATA)>
+<!ELEMENT role (#PCDATA)>
 <!ELEMENT authorBirth (#PCDATA)>
 <!ELEMENT authorDeath (#PCDATA)>
 <!ELEMENT desc (#PCDATA)>
 <!ELEMENT edition (#PCDATA)>
 <!ELEMENT pubPlace (#PCDATA)>
 <!ELEMENT pubName (#PCDATA)>
+<!ATTLIST pubName
+	  claimant (yes | no) "yes">
 <!ELEMENT pubDate (#PCDATA)>
-<!ELEMENT publisher (pubName?, pubPlace?, pubDate?)>
+<!ELEMENT publisher (#PCDATA | pubName | pubPlace | pubDate )* >
 <!ELEMENT volumes (#PCDATA)>
 <!ELEMENT vol (#PCDATA)>
 <!ELEMENT series (#PCDATA)>
 <!ELEMENT issuedInAnotherWork (#PCDATA)>
 <!ELEMENT otherauthor (#PCDATA)>
-<!ATTLIST otherauthor
-	  role NMTOKEN #IMPLIED>
 <!ELEMENT employerName (#PCDATA)>
 <!ELEMENT prev-regnum (#PCDATA)>
 <!ELEMENT newMatterClaimed (#PCDATA)>
 <!ELEMENT claimant (#PCDATA)>
 <!ELEMENT claimantPlace (#PCDATA)>
 <!ELEMENT regDate (#PCDATA)>
+<!ATTLIST regDate
+	  date CDATA #REQUIRED>
 <!ELEMENT classCode (#PCDATA)>
 <!ELEMENT copies (#PCDATA)>
 <!ATTLIST copies
-	  Date NMTOKEN #IMPLIED>
+	  date NMTOKEN #IMPLIED
+	  num CDATA #IMPLIED>
 <!ELEMENT affDate (#PCDATA)>
+<!ATTLIST affDate
+	  date CDATA #REQUIRED>
 <!ELEMENT noticeDate (#PCDATA)>
 <!ELEMENT see (#PCDATA)>
 <!ATTLIST see
 	  rid NMTOKEN #REQUIRED>
+<!ELEMENT registrationNumber (#PCDATA)>
 
 

--- a/examples/basic.xml
+++ b/examples/basic.xml
@@ -1,10 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE copyrightEntries SYSTEM "CopyrightEntries.dtd" []>
 <copyrightEntries>
+
+  <!-- 1927 Books For the Year 1927 New Series Vol 24 Part 1 p.3 -->
+  <!-- https://archive.org/stream/catalogofcopyrig241libr#page/3/mode/1up -->
+  
+  <copyrightEntry id="GUID1" regnum="A957926">
+    <author><authorName>Bunt, James</authorName></author>
+
+    <title>Rabbit diseases; cause, prevention, treatment and
+    cure</title> <author><role>by</role> <authorName>James
+    Bunt</authorName></author>... <publisher><pubPlace>Kansas City,
+    Mo.</pubPlace>, <pubName>The Outdoor enterprise publishing
+    company</pubName>, <pubDate>1926</pubDate></publisher>
+
+    <desc>22 p. illus. 19cm.</desc>
+
+    © <regDate date="1926-12-23">Dec. 23, 1926</regDate>; <copies
+    num="2">2c</copies> and aff. <affDate
+    date="1926-12-31">Dec. 31</affDate>; <registrationNumber>A
+    957926</registrationNumber>; <claimant>Outdoor enterprise
+    pub. co.</claimant> (27-1104) 17
+  </copyrightEntry>
+
+  <!-- 1930 Books For the Year 1930 New Series Vol 27 Part 1 p. 2 -->
+  <!-- https://archive.org/stream/catalogofcopyri271libr#page/2/mode/1up -->
+
+  <copyrightEntry id="GUID2" regnum="A17700">
+    <author><authorName>Burnett, William Riley</authorName>,
+    <authorBirth>1899</authorBirth>-</author>
+
+    <title>Iron Man</title> <author><role>by</role>
+    <authorName>W. R. Burnett</authorName></author>... <publisher><pubPlace>New
+    York</pubPlace>, <pubName>L. MacVeagh, The Dial
+    Press</pubName></publisher>;
+    <publisher><pubPlace>Toronto</pubPlace>, <pubName>Longmans, Green
+    and co.</pubName> [ᶜ<pubDate>1930</pubDate></publisher>
+
+    <desc> 5 p. l., 3-312 p. 19 ½ cm.</desc> © <regDate
+    date="1930-01-02">Jan. 2, 1930</regDate>; <copies
+    num="2">2c</copies> and aff. <affDate
+    date="1930-01-06">Jan. 6</affDate>; <registrationNumber>A
+    17700</registrationNumber>; <claimant>Dial Press, inc.</claimant>
+    (30-842) 11
+  </copyrightEntry>
+
   <!-- 1951 Books Jan-Dec 3D Ser Vol 5 Pt 1A p. 402 -->
   <!-- https://archive.org/stream/catalogofcopyri351libr#page/402/mode/1up -->
-  <copyrightEntry id="GUID1" regnum="A50966">
+  <copyrightEntry id="GUID3" regnum="A50966">
     <author><authorName>ADAMS, JAMES DONALD</authorName></author>.
+
     <title>Literary frontiers</title>.  <publisher><pubPlace>New
     York</pubPlace>, <pubName>Duell, Slone and
     Pearce</pubName></publisher>.  <desc>175 p.</desc> ©
@@ -12,4 +57,18 @@
     date="1950-06-06">6Jun51</regDate>;
     <registrationNumber>A56505</registrationNumber>.
   </copyrightEntry>
+
+
+  <!-- 1962 Books and Pamphlets July-Dec 3D Ser Vol 16 Pt 1 p. 1141 -->
+  <!-- https://archive.org/stream/catalogofcopyrig3161lib#page/1141/mode/1up -->
+  <copyrightEntry id="GUIDX" regnum="A578172">
+    <author><authorName>ADAMS, O. R.</authorName></author>
+
+    <title>Lameness in horses</title>. © <publisher><pubName
+    claimant="yes">Lea &amp; Febiger</pubName></publisher>;
+
+    <regDate date="1962-08-10">10Aug62</regDate>;
+    <registrationNumber>A578172</registrationNumber>.
+  </copyrightEntry>
+  
 </copyrightEntries>

--- a/examples/basic.xml
+++ b/examples/basic.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE copyrightEntries SYSTEM "CopyrightEntries.dtd" []>
+<copyrightEntries>
+  <!-- 1951 Books Jan-Dec 3D Ser Vol 5 Pt 1A p. 402 -->
+  <!-- https://archive.org/stream/catalogofcopyri351libr#page/402/mode/1up -->
+  <copyrightEntry id="GUID1" regnum="A50966">
+    <author><authorName>ADAMS, JAMES DONALD</authorName></author>.
+    <title>Literary frontiers</title>.  <publisher><pubPlace>New
+    York</pubPlace>, <pubName>Duell, Slone and
+    Pearce</pubName></publisher>.  <desc>175 p.</desc> ©
+    <claimant>J.Donald Adams</claimant>; <regDate
+    date="1950-06-06">6Jun51</regDate>;
+    <registrationNumber>A56505</registrationNumber>.
+  </copyrightEntry>
+</copyrightEntries>


### PR DESCRIPTION
Make the definition of `<copyrightEntry>` looser as described in #18, with marked up versions of those examples.