### PR TITLE
entryGroup and additionalEntry 

### DIFF
--- a/CopyrightEntries.dtd
+++ b/CopyrightEntries.dtd
@@ -26,6 +26,8 @@
 <!ATTLIST pubName
 	  claimant (yes | no) "yes">
 <!ELEMENT pubDate (#PCDATA)>
+<!ATTLIST pubDate
+	  date CDATA #IMPLIED>
 <!ELEMENT publisher (#PCDATA | pubName | pubPlace | pubDate )* >
 <!ELEMENT volumes (#PCDATA)>
 <!ELEMENT vol (#PCDATA)>
@@ -54,5 +56,7 @@
 <!ATTLIST see
 	  rid NMTOKEN #REQUIRED>
 <!ELEMENT registrationNumber (#PCDATA)>
-
+<!ELEMENT additionalEntry ANY>
+<!ATTLIST additionalEntry
+	  regnum NMTOKEN #REQUIRED>
 

--- a/CopyrightEntries.dtd
+++ b/CopyrightEntries.dtd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!ELEMENT copyrightEntries (copyrightEntry | crossRef)+ >
+<!ELEMENT copyrightEntries (copyrightEntry | crossRef | entryGroup)+ >
 <!ELEMENT copyrightEntry ANY>
 <!ATTLIST copyrightEntry
 	  id NMTOKEN #REQUIRED
@@ -8,6 +8,8 @@
 <!ELEMENT crossRef (#PCDATA | author | title | see)*>
 <!ATTLIST crossRef
 	  id NMTOKEN #REQUIRED>
+
+<!ELEMENT entryGroup (author, (copyrightEntry|crossRef)+)*>
           
 <!ELEMENT title (#PCDATA)>
 <!ELEMENT author (#PCDATA | role | authorName|  authorBirth | authorDeath)*>

--- a/examples/basic.xml
+++ b/examples/basic.xml
@@ -70,5 +70,30 @@
     <regDate date="1962-08-10">10Aug62</regDate>;
     <registrationNumber>A578172</registrationNumber>.
   </copyrightEntry>
-  
+
+  <!-- 1962 Books and Pamphlets July-Dec 3D Ser Vol 16 Pt 1 p. 1142 -->
+  <!-- https://archive.org/stream/catalogofcopyrig3161lib#page/1142/mode/1up -->
+  <entryGroup>
+    <author><authorName>ADLER, MORTIMER J.</authorName></author>
+    <copyrightEntry id="GUID4" regnum="A574004">
+      <title>Ethics; the study of moral values</title>,
+      <author><role>by</role> <authorName>Mortimer
+      J. Adler</authorName></author> &amp; <author><authorName>Seymour
+      Cain</authorName></author>. <author><role>Pref. by</role>
+      <authorName>William Ernest
+      Hocking</authorName></author>. (<series>The Great ideas program,
+      8</series>) © <claimant>Encyclopaedia Brittanica,
+      Inc.</claimant>; <regDate date="1962-07-02">2Jul62</regDate>;
+      <registrationNumber>A574004</registrationNumber>.
+    </copyrightEntry>
+
+    <copyrightEntry id="GUID5">
+      <title>Imaginative literatur I; from Homer
+      to Shakespeare</title>, <author><role>by</role> <authorName>Mortimer J.
+      Adler</authorName></author> &amp; <author><authorName>Seymour Cain</authorName></author>. <author><role>Pref. by</role>
+      <authorName>Saul Bellow</authorName></author>. (<series>The Great ideas
+      program, 6</series>) © <claimant>Encyclopaedia
+      Brittanica, Inc.</claimant>; <regDate date="1961-12-01">1Dec61</regDate>; <registrationNumber>A574002</registrationNumber>.
+    </copyrightEntry>
+  </entryGroup>
 </copyrightEntries>

--- a/examples/basic.xml
+++ b/examples/basic.xml
@@ -73,6 +73,11 @@
 
   <!-- 1962 Books and Pamphlets July-Dec 3D Ser Vol 16 Pt 1 p. 1142 -->
   <!-- https://archive.org/stream/catalogofcopyrig3161lib#page/1142/mode/1up -->
+
+  <!-- MULTIPLE ENTRIES UNDER A SINGLE AUTHOR
+       A single entryGroup with a single author
+       Each entry is a copyrightEntry in the group
+       The author can be (probably is) repeated in each entry -->
   <entryGroup>
     <author><authorName>ADLER, MORTIMER J.</authorName></author>
     <copyrightEntry id="GUID4" regnum="A574004">
@@ -87,13 +92,57 @@
       <registrationNumber>A574004</registrationNumber>.
     </copyrightEntry>
 
-    <copyrightEntry id="GUID5">
-      <title>Imaginative literatur I; from Homer
-      to Shakespeare</title>, <author><role>by</role> <authorName>Mortimer J.
-      Adler</authorName></author> &amp; <author><authorName>Seymour Cain</authorName></author>. <author><role>Pref. by</role>
-      <authorName>Saul Bellow</authorName></author>. (<series>The Great ideas
-      program, 6</series>) © <claimant>Encyclopaedia
-      Brittanica, Inc.</claimant>; <regDate date="1961-12-01">1Dec61</regDate>; <registrationNumber>A574002</registrationNumber>.
+    <copyrightEntry id="GUID5" regnum="A574002">
+      <title>Imaginative literatur I; from Homer to
+      Shakespeare</title>, <author><role>by</role>
+      <authorName>Mortimer J.  Adler</authorName></author> &amp;
+      <author><authorName>Seymour
+      Cain</authorName></author>. <author><role>Pref. by</role>
+      <authorName>Saul Bellow</authorName></author>. (<series>The
+      Great ideas program, 6</series>) © <claimant>Encyclopaedia
+      Brittanica, Inc.</claimant>; <regDate
+      date="1961-12-01">1Dec61</regDate>;
+      <registrationNumber>A574002</registrationNumber>.
     </copyrightEntry>
   </entryGroup>
+
+  <!-- 1962 Books and Pamphlets July-Dec 3D Ser Vol 16 Pt 1 p. 1144 -->
+  <!-- https://archive.org/stream/catalogofcopyrig3161lib#page/1144/mode/1up -->
+
+  <!-- MULTIPLE REGISTRATIONS UNDER A SINGLE TITLE
+       One copyrightEntry through the first registration
+       One additionalEntry per... additionalEntry
+       Repeat whatever needs to be repeated 
+       copyrightEntry regnum attribute should be the number of the FIRST
+       registration. Each additionEntry then has its own regnum. -->
+  <copyrightEntry id="GUID6" regnum="BB21264">
+    <title>THE ADVENTURES OF HAP HAZARD</title> <note>(in The
+    Co-operator)</note> <author><role>Appl. author</role>:
+    <authorName>Jack Hamilton</authorName></author>. ©
+    <publisher><pubName claimant="yes">Employers Casualty
+    Co.</pubName> <pubDate date="1962-07">Jul62></pubDate></publisher>
+    © <regDate date="1962-07-12">12Jul</regDate>;
+    <registrationNumber>BB21264</registrationNumber>.
+    <additionalEntry regnum="BB21524">
+      <pubDate date="1962-08">Aug62</pubDate>
+      © <regDate date="1962-08-15">15Aug</regDate>;
+      <registrationNumber>BB21524</registrationNumber>
+    </additionalEntry>.
+    <additionalEntry regnum="BB21695">
+      <pubDate date="1962-09">Sep62</pubDate>
+      © <regDate date="1962-09-11">11Sep</regDate>;
+      <registrationNumber>BB21695</registrationNumber>
+    </additionalEntry>.
+    <additionalEntry regnum="BB21839">
+      <pubDate date="1962-10">Oct62</pubDate>
+      © <regDate date="1962-10-05">5Oct</regDate>;
+      <registrationNumber>BB21839</registrationNumber>
+    </additionalEntry>.
+    <additionalEntry regnum="BB22021">
+      <pubDate date="1962-11">Oct62</pubDate>
+      © <regDate date="1962-10-23">23Oct</regDate>;
+      <registrationNumber>BB22010</registrationNumber>
+    </additionalEntry>.
+  </copyrightEntry>
+  
 </copyrightEntries>


### PR DESCRIPTION
Adds to mechanism for dealing with repetitions:`<entryGroup>`  and`<additionalEntry>`.

`<entryGroup>` is for cases where a single author has multiple `<copyrightEntries>` and simply acts as a container for the entries:

![screen shot 2018-04-03 at 11 17 16 am](https://user-images.githubusercontent.com/720703/38258531-b595d060-3730-11e8-8391-e760b1d0c7bb.png)

    <entryGroup>
        <author><authorName>ADLER, MORTIMER J.</authorName></author>
        <copyrightEntry>
        <copyrightEntry>
    </entryGroup>

`<additionalEntry>` is for cases where a single title as continued by parts that have their own registrations (most likely issues of a periodical)

![screen shot 2018-04-03 at 11 17 03 am](https://user-images.githubusercontent.com/720703/38258708-300ecdc4-3731-11e8-98f9-8d339ec290c5.png)

    <copyrightEntry id="GUID6" regnum="BB21264">
        <title>THE ADVENTURES OF HAP HAZARD</title> <note>(in The
        Co-operator)</note> <author><role>Appl. author</role>:
        <authorName>Jack Hamilton</authorName></author>. ©
        <publisher><pubName claimant="yes">Employers Casualty
        Co.</pubName> <pubDate date="1962-07">Jul62></pubDate></publisher>
        © <regDate date="1962-07-12">12Jul</regDate>;
        <registrationNumber>BB21264</registrationNumber>.
        <additionalEntry regnum="BB21524">
            <pubDate date="1962-08">Aug62</pubDate>
            © <regDate date="1962-08-15">15Aug</regDate>;
            <registrationNumber>BB21524</registrationNumber>
        </additionalEntry>.
        <!-- more additionalEntry elements -->
    </copyrightEntry>

Note, the containing `<copyrightEntry>` has the the first registration number. Whatever needs to be repeated in each `<additionalEntry>` can be repeated.



Fixes #16 