### PR TITLE
Authors with places and claims

### DIFF
--- a/CopyrightEntries.dtd
+++ b/CopyrightEntries.dtd
@@ -10,10 +10,13 @@
 	  id NMTOKEN #REQUIRED>
           
 <!ELEMENT title (#PCDATA)>
-<!ELEMENT author (#PCDATA | role | authorName|  authorBirth | authorDeath)*>
+<!ELEMENT author (#PCDATA | role | authorName|  authorBirth | authorDeath |
+	  authorPlace)*>
 <!ATTLIST author
+	  claimant (yes | no) "yes"
 	  role NMTOKEN #IMPLIED>
 <!ELEMENT authorName (#PCDATA)>
+<!ELEMENT authorPlace (#PCDATA)>
 <!ELEMENT role (#PCDATA)>
 <!ELEMENT authorBirth (#PCDATA)>
 <!ELEMENT authorDeath (#PCDATA)>

--- a/examples/basic.xml
+++ b/examples/basic.xml
@@ -45,6 +45,33 @@
     (30-842) 11
   </copyrightEntry>
 
+  <copyrightEntry id="GUI7" regnum="A190420">
+    <author claimant="yes"><authorName>Curtis, Charles P.,
+    jr.</authorName>,* <authorPlace>Ipswich,
+    Mass.</authorPlace></author> &amp; <author
+    claimant="yes"><authorName>Greenslet, Ferris</authorName>,*
+    <authorPlace>Boston</authorPlace></author>. <title>The practical
+    cogitator</title>. <author><role>selected and edited by</role>
+    <authorName>C. P. Curtis, jr.</authorName></author> and
+    <author><authorName>Ferris Greenslet</authorName></author>. ©
+    <regDate date="1945-10-09">>Oct. 9, 1945</regDate>;
+    <registrationNumber>A 190420</registrationNumber>.
+  </copyrightEntry>
+
+  <copyrightEntry id="GUI8" regnum="A189950">
+    <author claimant="yes"><authorName>Cuthbert,
+    Margaret</authorName>,* <authorPlace>New
+    York</authorPlace></author>. <title>Adventure in radio</title>,
+    <author><role>edited by</role>
+    <authorName>M. Cuthbert</authorName></author>, <author><role>with
+    radio scripts by</role> <authorName>Edna St.  Vincent
+    Millay</authorName></author>, <author><authorName>Arch
+    Obeler</authorName></author>, <author><authorName>Archibald
+    MacLeish</authorName></author> <note>[and others]</note> ©
+    <regDate date="1945-09-17">Sept.  17, 1945</regDate>;
+    <registrationNumber>A 189950</registrationNumber>. 5511
+  </copyrightEntry>
+
   <!-- 1951 Books Jan-Dec 3D Ser Vol 5 Pt 1A p. 402 -->
   <!-- https://archive.org/stream/catalogofcopyri351libr#page/402/mode/1up -->
   <copyrightEntry id="GUID3" regnum="A50966">


### PR DESCRIPTION
In some entries an author's name is followed by a place. Add
<authorPlace> as a child of <author> to hold this info.

Add isclaimant attribute to <author> for when there are indications,
such as an asterisk that the author is the copyright claimant (we
won't markup the asterisk in any way).

Add examples.

Fixes #22